### PR TITLE
5.7

### DIFF
--- a/attributes/page_selector/controller.php
+++ b/attributes/page_selector/controller.php
@@ -52,7 +52,8 @@ class Controller extends \Concrete\Core\Attribute\Controller  {
 		$arr = $this->attributeKey->getAttributeValueIDList();
 		foreach($arr as $id) {
 			$db->Execute('delete from atPageSelector where avID = ?', array($id));
-		}
+        }
+        parent::deleteKey();
 	}
 	
 	public function saveForm($data) {

--- a/controller.php
+++ b/controller.php
@@ -9,7 +9,7 @@ class Controller extends \Concrete\Core\Package\Package {
 
 	protected $pkgHandle = 'page_selector_attribute';
 	protected $appVersionRequired = '5.7.1';
-	protected $pkgVersion = '2.0';
+	protected $pkgVersion = '2.1';
 	
 	public function getPackageDescription() {
 		return t("Attribute that allows the selection of pages.");


### PR DESCRIPTION
Fixes the exceptions that were being thrown when you tried to delete a page_selector_attribute attribute key. 