### PR TITLE
Fix deleting an attribute key

### DIFF
--- a/attributes/page_selector/controller.php
+++ b/attributes/page_selector/controller.php
@@ -48,6 +48,7 @@ class Controller extends \Concrete\Core\Attribute\Controller  {
 	}
 	
 	public function deleteKey() {
+		parent::deleteKey();
 		$db = Loader::db();
 		$arr = $this->attributeKey->getAttributeValueIDList();
 		foreach($arr as $id) {


### PR DESCRIPTION
This fixes this issue: https://www.concrete5.org/marketplace/addons/page-selector-attribute1/support/deleting-an-attribute-key-was-throwing-a-sql-foreign-key-constra/